### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include jhu_primitives/*/*.R
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -121,5 +121,6 @@ setup(
                      ],
     url='https://github.com/neurodata/primitives-interfaces',
     dependency_links=['git+https://github.com/neurodata/graspy.git#egg=master'],
-    keywords = 'd3m_primitive'
+    keywords = 'd3m_primitive',
+    license = 'Apache-2.0',
 )


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.