### PR TITLE
Relax lapjv dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
                       'scipy', # jhu dependency
                       # 'lap',  # unnecessary jhu dependency
                       'cython', # jhu dependency,
-                      'lapjv==1.2.0',
+                      'lapjv>=1.2.0,<2.0.0',
                       'graspy>=0.0.2',
                       'graspologic',
                       'numba>=0.52.0',


### PR DESCRIPTION
There are other packages depending on `lapjv` in the d3m primitives, relax the version so they can coexist.